### PR TITLE
Add minimal escrow marketplace demo

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  root: true,
+  parser: '@typescript-eslint/parser',
+  extends: ['eslint:recommended', 'plugin:react-hooks/recommended', 'prettier'],
+  plugins: ['@typescript-eslint'],
+  env: { browser: true, node: true, es2022: true }
+};

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+      - name: Install Rust deps
+        run: cargo install cargo-deny
+      - name: Lint Rust
+        run: cargo clippy --manifest-path programs/escrow_market/Cargo.toml -- -D warnings
+      - name: Anchor test
+        run: anchor test
+      - name: Frontend lint
+        run: |
+          cd app
+          npm ci
+          npm run lint
+          npm run build

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "es5"
+}

--- a/Anchor.toml
+++ b/Anchor.toml
@@ -1,0 +1,8 @@
+[programs.localnet]
+escrow_market = "Escrow1111111111111111111111111111111111111"
+
+[registry]
+url = "https://anchor.projectserum.com"
+
+[scripts]
+test = "ts-mocha -p ./ts/tsconfig.json -t 1000000 ts/tests/**/*.ts"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,2 @@
+[workspace]
+members = ["programs/escrow_market"]

--- a/IDL/escrow_market.json
+++ b/IDL/escrow_market.json
@@ -1,0 +1,89 @@
+{
+  "version": "0.1.0",
+  "name": "escrow_market",
+  "instructions": [
+    {
+      "name": "createListing",
+      "accounts": [
+        { "name": "seller", "isMut": true, "isSigner": true },
+        { "name": "listing", "isMut": true, "isSigner": false },
+        { "name": "mint", "isMut": false, "isSigner": false },
+        { "name": "sellerTokenAccount", "isMut": true, "isSigner": false },
+        { "name": "escrowTokenAccount", "isMut": true, "isSigner": false },
+        { "name": "tokenProgram", "isMut": false, "isSigner": false },
+        { "name": "associatedTokenProgram", "isMut": false, "isSigner": false },
+        { "name": "systemProgram", "isMut": false, "isSigner": false },
+        { "name": "rent", "isMut": false, "isSigner": false }
+      ],
+      "args": [
+        { "name": "price", "type": "u64" },
+        { "name": "quantity", "type": "u64" },
+        { "name": "expiry", "type": "i64" },
+        { "name": "nonce", "type": "u64" }
+      ]
+    },
+    {
+      "name": "buy",
+      "accounts": [
+        { "name": "buyer", "isMut": true, "isSigner": true },
+        { "name": "listing", "isMut": true, "isSigner": false },
+        { "name": "buyerPaymentAccount", "isMut": true, "isSigner": false },
+        { "name": "buyerReceiveAccount", "isMut": true, "isSigner": false },
+        { "name": "sellerReceivingAccount", "isMut": true, "isSigner": false },
+        { "name": "escrowTokenAccount", "isMut": true, "isSigner": false },
+        { "name": "feeVault", "isMut": true, "isSigner": false },
+        { "name": "feeVaultAuthority", "isMut": false, "isSigner": false },
+        { "name": "tokenProgram", "isMut": false, "isSigner": false }
+      ],
+      "args": []
+    },
+    {
+      "name": "cancel",
+      "accounts": [
+        { "name": "authority", "isMut": false, "isSigner": true },
+        { "name": "listing", "isMut": true, "isSigner": false },
+        { "name": "seller", "isMut": false, "isSigner": false },
+        { "name": "sellerTokenAccount", "isMut": true, "isSigner": false },
+        { "name": "escrowTokenAccount", "isMut": true, "isSigner": false },
+        { "name": "tokenProgram", "isMut": false, "isSigner": false }
+      ],
+      "args": []
+    },
+    {
+      "name": "withdrawFee",
+      "accounts": [
+        { "name": "admin", "isMut": true, "isSigner": true },
+        { "name": "adminFeeAccount", "isMut": true, "isSigner": false },
+        { "name": "feeVault", "isMut": true, "isSigner": false },
+        { "name": "feeVaultAuthority", "isMut": false, "isSigner": false },
+        { "name": "tokenProgram", "isMut": false, "isSigner": false }
+      ],
+      "args": [{ "name": "amount", "type": "u64" }]
+    }
+  ],
+  "accounts": [
+    {
+      "name": "listing",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          { "name": "seller", "type": "publicKey" },
+          { "name": "mint", "type": "publicKey" },
+          { "name": "price", "type": "u64" },
+          { "name": "quantity", "type": "u64" },
+          { "name": "expiry", "type": "i64" },
+          { "name": "status", "type": "u8" },
+          { "name": "bump", "type": "u8" },
+          { "name": "nonce", "type": "u64" }
+        ]
+      }
+    }
+  ],
+  "errors": [
+    { "code": 6000, "name": "InvalidState", "msg": "Listing is not in correct state" },
+    { "code": 6001, "name": "Unauthorized", "msg": "Unauthorized" },
+    { "code": 6002, "name": "Overflow", "msg": "Overflow" },
+    { "code": 6003, "name": "InvalidQuantity", "msg": "Invalid quantity" },
+    { "code": 6004, "name": "InvalidPrice", "msg": "Invalid price" }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,43 @@
-# Solana-Anchor-Escrow
+# Solana Escrow Marketplace (Demo)
+
+Minimal, production-style escrow marketplace built with Anchor.  
+Users create listings for an SPL token, lock assets in escrow, and buyers purchase them in a single transaction with platform fees.
+
+## Stack
+- Anchor + Rust on-chain program
+- React + Vite + TypeScript frontend
+- SPL Token, Associated Token programs
+- Wallet adapter (Phantom)
+- Mocha/Anchor tests
+- Linting via ESLint/Prettier, `cargo clippy`, `cargo-deny`
+
+## Quickstart
+```bash
+# Build & test program
+anchor build
+anchor test
+
+# Start frontend
+cd app
+npm install
+npm run dev
+```
+
+## Env
+Frontend expects:
+```
+VITE_RPC_URL=https://api.devnet.solana.com
+VITE_PROGRAM_ID=Escrow1111111111111111111111111111111111111
+VITE_MINT=<token mint>
+```
+
+## Deploy
+```
+anchor deploy
+# update VITE_PROGRAM_ID in .env or vite config
+```
+
+## Notes
+- Fee vault collects platform fees; admin withdraw using `withdrawFee`.
+- Example only: no partial fills, assumes single mint, and demo admin key.
+- Future: partial fills, NFT support, Token-2022, multisig admin.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,30 @@
+# Security
+
+## Threat Model
+- Malicious buyer/seller attempting double spend or unauthorized withdrawals.
+- CPI into untrusted programs.
+
+## Permissions
+| Instruction    | Who can call                                     |
+|----------------|--------------------------------------------------|
+| `createListing`| Seller (signer)                                  |
+| `buy`          | Buyer (signer) while listing `Open`              |
+| `cancel`       | Seller or anyone after `expiry`                  |
+| `withdrawFee`  | Admin only (demo key hard coded)                 |
+
+## Upgrade Authority
+The program upgrade authority is a single key for demo purposes.  
+In production, a multisig should own upgrades.
+
+## Reentrancy & Replay
+Solana transaction model executes atomically; however, we:
+- Update listing state **before** transfers on `buy`.
+- Reject any instruction if `status != Open`.
+
+## CPI Allowlist
+Only CPI to SPL Token & Associated Token program.  
+Additional CPI should be explicitly whitelisted.
+
+## Integer Safety
+All arithmetic uses `checked_*` operations with early overflow checks.  
+Inputs validated for non-zero price/quantity.

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,57 @@
+# Specification
+
+## Accounts
+### Listing
+Seeds: `["listing", seller, mint, nonce]`  
+Fields: seller, mint, price, quantity, expiry, status, bump, nonce.
+
+### FeeVault
+Seeds: `["fee_vault"]` – SPL token account to hold platform fees.
+
+### Escrow ATA
+Associated token account for listing PDA + mint.
+
+## Status Machine
+```
+Open -> Settled (on `buy`)
+Open -> Canceled (on `cancel`)
+```
+No further transitions allowed.
+
+## Instructions
+### createListing(price, quantity, expiry, nonce)
+- seller signs.
+- Transfers `quantity` of `mint` to escrow ATA.
+- Emits `ListingCreated`.
+
+### buy()
+- buyer signs.
+- Checks `status == Open`; sets to Settled.
+- Transfers `price` from buyer to seller minus fee.
+- Transfers fee to FeeVault.
+- Releases escrowed tokens to buyer.
+- Emits `Purchased`.
+
+### cancel()
+- seller or anyone after expiry.
+- Status must be Open.
+- Releases escrow to seller.
+- Emits `Canceled`.
+
+### withdrawFee(amount)
+- admin signer.
+- Moves `amount` from FeeVault to admin account.
+- Emits `FeeWithdrawn`.
+
+## Events
+- `ListingCreated { seller, listing, mint, price, quantity }`
+- `Purchased { listing, buyer, price }`
+- `Canceled { listing, seller }`
+- `FeeWithdrawn { admin, amount }`
+
+## Errors
+- `InvalidState`
+- `Unauthorized`
+- `Overflow`
+- `InvalidQuantity`
+- `InvalidPrice`

--- a/app/index.html
+++ b/app/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Escrow Market</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/app/package.json
+++ b/app/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "escrow-market-app",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "lint": "eslint . --ext ts,tsx"
+  },
+  "dependencies": {
+    "@coral-xyz/anchor": "^0.29.0",
+    "@solana/wallet-adapter-react": "^0.9.21",
+    "@solana/wallet-adapter-react-ui": "^0.9.21",
+    "@solana/wallet-adapter-wallets": "^0.19.16",
+    "@solana/web3.js": "^1.80.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.9.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.28",
+    "@types/react-dom": "^18.0.11",
+    "@vitejs/plugin-react": "^4.0.0",
+    "eslint": "^8.37.0",
+    "eslint-config-prettier": "^8.8.0",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "prettier": "^2.8.8",
+    "typescript": "^5.0.4",
+    "vite": "^4.3.0"
+  }
+}

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,0 +1,21 @@
+import { BrowserRouter, Link, Route, Routes } from 'react-router-dom';
+import Listings from './pages/Listings';
+import MyListings from './pages/MyListings';
+import { WalletContextProvider } from './lib/wallet';
+
+export default function App() {
+  return (
+    <WalletContextProvider>
+      <BrowserRouter>
+        <nav style={{ display: 'flex', gap: '1rem' }}>
+          <Link to="/">Listings</Link>
+          <Link to="/my">My Listings</Link>
+        </nav>
+        <Routes>
+          <Route path="/" element={<Listings />} />
+          <Route path="/my" element={<MyListings />} />
+        </Routes>
+      </BrowserRouter>
+    </WalletContextProvider>
+  );
+}

--- a/app/src/components/CreateListingForm.tsx
+++ b/app/src/components/CreateListingForm.tsx
@@ -1,0 +1,31 @@
+import { useState } from 'react';
+import { useAnchor } from '../lib/anchorClient';
+import { BN } from '@coral-xyz/anchor';
+
+export default function CreateListingForm() {
+  const { program, wallet } = useAnchor();
+  const [price, setPrice] = useState('');
+  const [qty, setQty] = useState('');
+  const [expiry, setExpiry] = useState('');
+
+  const submit = async () => {
+    if (!program || !wallet) return;
+    const nonce = Date.now();
+    await program.methods
+      .createListing(new BN(price), new BN(qty), new BN(expiry), new BN(nonce))
+      .accounts({
+        seller: wallet.publicKey,
+      })
+      .rpc();
+  };
+
+  return (
+    <div>
+      <h3>Create Listing</h3>
+      <input placeholder="Price" value={price} onChange={(e) => setPrice(e.target.value)} />
+      <input placeholder="Quantity" value={qty} onChange={(e) => setQty(e.target.value)} />
+      <input placeholder="Expiry (unix)" value={expiry} onChange={(e) => setExpiry(e.target.value)} />
+      <button onClick={submit}>Submit</button>
+    </div>
+  );
+}

--- a/app/src/components/ListingCard.tsx
+++ b/app/src/components/ListingCard.tsx
@@ -1,0 +1,36 @@
+import { useAnchor } from '../lib/anchorClient';
+import { PublicKey } from '@solana/web3.js';
+
+interface Props {
+  listing: any;
+}
+
+export default function ListingCard({ listing }: Props) {
+  const { program, wallet } = useAnchor();
+
+  const buy = async () => {
+    if (!program || !wallet) return;
+    await program.methods.buy().accounts({ buyer: wallet.publicKey, listing: listing.publicKey }).rpc();
+  };
+
+  const cancel = async () => {
+    if (!program || !wallet) return;
+    await program.methods.cancel().accounts({
+      authority: wallet.publicKey,
+      listing: listing.publicKey,
+      seller: new PublicKey(listing.account.seller),
+    }).rpc();
+  };
+
+  return (
+    <div style={{ border: '1px solid gray', padding: '1rem', margin: '0.5rem' }}>
+      <div>Seller: {listing.account.seller}</div>
+      <div>Price: {listing.account.price.toString()}</div>
+      <div>Quantity: {listing.account.quantity.toString()}</div>
+      <div>Expiry: {listing.account.expiry.toString()}</div>
+      <div>Status: {listing.account.status}</div>
+      <button onClick={buy}>Buy</button>
+      <button onClick={cancel}>Cancel</button>
+    </div>
+  );
+}

--- a/app/src/components/TxToast.tsx
+++ b/app/src/components/TxToast.tsx
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react';
+
+export default function TxToast({ signature }: { signature?: string }) {
+  const [url, setUrl] = useState<string>();
+
+  useEffect(() => {
+    if (signature) {
+      setUrl(`https://solscan.io/tx/${signature}?cluster=devnet`);
+    }
+  }, [signature]);
+
+  if (!signature) return null;
+  return (
+    <div style={{ position: 'fixed', bottom: 10, right: 10, background: '#eee', padding: '0.5rem' }}>
+      <a href={url} target="_blank" rel="noreferrer">
+        View transaction
+      </a>
+    </div>
+  );
+}

--- a/app/src/lib/anchorClient.ts
+++ b/app/src/lib/anchorClient.ts
@@ -1,0 +1,14 @@
+import { AnchorProvider, Program, Idl } from '@coral-xyz/anchor';
+import { Connection, PublicKey } from '@solana/web3.js';
+import { useWallet } from '@solana/wallet-adapter-react';
+import idl from '../../../IDL/escrow_market.json';
+
+const programId = new PublicKey(import.meta.env.VITE_PROGRAM_ID || 'Escrow1111111111111111111111111111111111111');
+
+export const useAnchor = () => {
+  const wallet = useWallet();
+  const connection = new Connection(import.meta.env.VITE_RPC_URL || 'https://api.devnet.solana.com');
+  const provider = wallet.publicKey ? new AnchorProvider(connection, wallet, {}) : undefined;
+  const program = provider ? new Program(idl as Idl, programId, provider) : undefined;
+  return { program, wallet };
+};

--- a/app/src/lib/wallet.ts
+++ b/app/src/lib/wallet.ts
@@ -1,0 +1,18 @@
+import { FC, ReactNode } from 'react';
+import { ConnectionProvider, WalletProvider } from '@solana/wallet-adapter-react';
+import { WalletModalProvider } from '@solana/wallet-adapter-react-ui';
+import { PhantomWalletAdapter } from '@solana/wallet-adapter-wallets';
+
+require('@solana/wallet-adapter-react-ui/styles.css');
+
+export const WalletContextProvider: FC<{ children: ReactNode }> = ({ children }) => {
+  const endpoint = import.meta.env.VITE_RPC_URL || 'https://api.devnet.solana.com';
+  const wallets = [new PhantomWalletAdapter()];
+  return (
+    <ConnectionProvider endpoint={endpoint}>
+      <WalletProvider wallets={wallets} autoConnect>
+        <WalletModalProvider>{children}</WalletModalProvider>
+      </WalletProvider>
+    </ConnectionProvider>
+  );
+};

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/app/src/pages/Listings.tsx
+++ b/app/src/pages/Listings.tsx
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+import { useAnchor } from '../lib/anchorClient';
+import ListingCard from '../components/ListingCard';
+
+export default function Listings() {
+  const { program } = useAnchor();
+  const [listings, setListings] = useState<any[]>([]);
+
+  useEffect(() => {
+    const load = async () => {
+      if (!program) return;
+      const all = await program.account.listing.all();
+      setListings(all.filter((l) => l.account.status === 0));
+    };
+    load();
+  }, [program]);
+
+  return (
+    <div>
+      <h2>Open Listings</h2>
+      {listings.map((l) => (
+        <ListingCard key={l.publicKey.toBase58()} listing={l} />
+      ))}
+    </div>
+  );
+}

--- a/app/src/pages/MyListings.tsx
+++ b/app/src/pages/MyListings.tsx
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react';
+import { useAnchor } from '../lib/anchorClient';
+import CreateListingForm from '../components/CreateListingForm';
+import ListingCard from '../components/ListingCard';
+
+export default function MyListings() {
+  const { program, wallet } = useAnchor();
+  const [mine, setMine] = useState<any[]>([]);
+
+  useEffect(() => {
+    const load = async () => {
+      if (!program || !wallet?.publicKey) return;
+      const all = await program.account.listing.all([
+        {
+          memcmp: { offset: 8, bytes: wallet.publicKey.toBase58() }
+        }
+      ]);
+      setMine(all);
+    };
+    load();
+  }, [program, wallet]);
+
+  return (
+    <div>
+      <CreateListingForm />
+      <h2>My Listings</h2>
+      {mine.map((l) => (
+        <ListingCard key={l.publicKey.toBase58()} listing={l} />
+      ))}
+    </div>
+  );
+}

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "jsx": "react-jsx",
+    "strict": true,
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()]
+});

--- a/programs/escrow_market/Cargo.toml
+++ b/programs/escrow_market/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "escrow_market"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+[dependencies]
+anchor-lang = "0.29.0"
+anchor-spl = "0.29.0"

--- a/programs/escrow_market/src/lib.rs
+++ b/programs/escrow_market/src/lib.rs
@@ -1,0 +1,417 @@
+use anchor_lang::prelude::*;
+use anchor_spl::associated_token::AssociatedToken;
+use anchor_spl::token::{self, CloseAccount, Mint, Token, TokenAccount, Transfer};
+
+declare_id!("Escrow1111111111111111111111111111111111111");
+
+pub const FEE_BPS: u16 = 100; // 1%
+pub const ADMIN_PUBKEY: Pubkey = pubkey!("FEEAdm11111111111111111111111111111111111");
+
+#[program]
+pub mod escrow_market {
+    use super::*;
+
+    pub fn create_listing(
+        ctx: Context<CreateListing>,
+        price: u64,
+        quantity: u64,
+        expiry: i64,
+        nonce: u64,
+    ) -> Result<()> {
+        require!(quantity > 0, EscrowError::InvalidQuantity);
+        require!(price > 0, EscrowError::InvalidPrice);
+
+        token::transfer(
+            ctx.accounts.transfer_to_escrow_context(),
+            quantity,
+        )?;
+
+        let listing = &mut ctx.accounts.listing;
+        listing.seller = ctx.accounts.seller.key();
+        listing.mint = ctx.accounts.mint.key();
+        listing.price = price;
+        listing.quantity = quantity;
+        listing.expiry = expiry;
+        listing.status = ListingStatus::Open as u8;
+        listing.bump = *ctx.bumps.get("listing").unwrap();
+        listing.nonce = nonce;
+
+        emit!(ListingCreated {
+            seller: listing.seller,
+            listing: listing.key(),
+            mint: listing.mint,
+            price,
+            quantity,
+        });
+
+        Ok(())
+    }
+
+    pub fn buy(ctx: Context<Buy>) -> Result<()> {
+        let listing = &mut ctx.accounts.listing;
+        require!(
+            listing.status == ListingStatus::Open as u8,
+            EscrowError::InvalidState
+        );
+        listing.status = ListingStatus::Settled as u8;
+
+        let fee = listing
+            .price
+            .checked_mul(FEE_BPS as u64)
+            .ok_or(EscrowError::Overflow)?
+            .checked_div(10_000)
+            .ok_or(EscrowError::Overflow)?;
+        let seller_amount = listing
+            .price
+            .checked_sub(fee)
+            .ok_or(EscrowError::Overflow)?;
+
+        token::transfer(ctx.accounts.pay_seller_context(), seller_amount)?;
+        token::transfer(ctx.accounts.pay_fee_context(), fee)?;
+        token::transfer(
+            ctx.accounts
+                .escrow_to_buyer_context()
+                .with_signer(&[ctx.accounts.listing_seeds()]),
+            listing.quantity,
+        )?;
+        token::close_account(
+            ctx.accounts
+                .close_escrow_context()
+                .with_signer(&[ctx.accounts.listing_seeds()]),
+        )?;
+
+        emit!(Purchased {
+            listing: listing.key(),
+            buyer: ctx.accounts.buyer.key(),
+            price: listing.price,
+        });
+
+        Ok(())
+    }
+
+    pub fn cancel(ctx: Context<Cancel>) -> Result<()> {
+        let listing = &mut ctx.accounts.listing;
+        require!(
+            listing.status == ListingStatus::Open as u8,
+            EscrowError::InvalidState
+        );
+        let now = Clock::get()?.unix_timestamp;
+        require!(
+            ctx.accounts.authority.key() == listing.seller || now > listing.expiry,
+            EscrowError::Unauthorized
+        );
+
+        listing.status = ListingStatus::Canceled as u8;
+
+        token::transfer(
+            ctx.accounts
+                .escrow_to_seller_context()
+                .with_signer(&[ctx.accounts.listing_seeds()]),
+            listing.quantity,
+        )?;
+        token::close_account(
+            ctx.accounts
+                .close_escrow_context()
+                .with_signer(&[ctx.accounts.listing_seeds()]),
+        )?;
+
+        emit!(Canceled {
+            listing: listing.key(),
+            seller: listing.seller,
+        });
+
+        Ok(())
+    }
+
+    pub fn withdraw_fee(ctx: Context<WithdrawFee>, amount: u64) -> Result<()> {
+        require_keys_eq!(ctx.accounts.admin.key(), ADMIN_PUBKEY, EscrowError::Unauthorized);
+
+        token::transfer(
+            ctx.accounts
+                .vault_to_admin_context()
+                .with_signer(&[&[b"fee_vault", &[ctx.bumps.fee_vault_authority]]]),
+            amount,
+        )?;
+
+        emit!(FeeWithdrawn {
+            admin: ctx.accounts.admin.key(),
+            amount,
+        });
+
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+#[instruction(price: u64, quantity: u64, expiry: i64, nonce: u64)]
+pub struct CreateListing<'info> {
+    #[account(mut)]
+    pub seller: Signer<'info>,
+    #[account(
+        init,
+        payer = seller,
+        space = Listing::LEN,
+        seeds = [b"listing", seller.key().as_ref(), mint.key().as_ref(), &nonce.to_le_bytes()],
+        bump
+    )]
+    pub listing: Account<'info, Listing>,
+    pub mint: Account<'info, Mint>,
+    #[account(
+        mut,
+        constraint = seller_token_account.owner == seller.key(),
+        constraint = seller_token_account.mint == mint.key(),
+    )]
+    pub seller_token_account: Account<'info, TokenAccount>,
+    #[account(
+        mut,
+        associated_token::mint = mint,
+        associated_token::authority = listing,
+    )]
+    pub escrow_token_account: Account<'info, TokenAccount>,
+    pub token_program: Program<'info, Token>,
+    pub associated_token_program: Program<'info, AssociatedToken>,
+    pub system_program: Program<'info, System>,
+    pub rent: Sysvar<'info, Rent>,
+}
+
+impl<'info> CreateListing<'info> {
+    fn transfer_to_escrow_context(&self) -> CpiContext<'_, '_, '_, 'info, Transfer<'info>> {
+        let cpi_accounts = Transfer {
+            from: self.seller_token_account.to_account_info(),
+            to: self.escrow_token_account.to_account_info(),
+            authority: self.seller.to_account_info(),
+        };
+        CpiContext::new(self.token_program.to_account_info(), cpi_accounts)
+    }
+}
+
+#[derive(Accounts)]
+pub struct Buy<'info> {
+    #[account(mut)]
+    pub buyer: Signer<'info>,
+    #[account(mut)]
+    pub listing: Account<'info, Listing>,
+    #[account(
+        mut,
+        constraint = buyer_payment_account.owner == buyer.key(),
+        constraint = buyer_payment_account.mint == listing.mint
+    )]
+    pub buyer_payment_account: Account<'info, TokenAccount>,
+    #[account(
+        mut,
+        constraint = buyer_receive_account.owner == buyer.key(),
+        constraint = buyer_receive_account.mint == listing.mint
+    )]
+    pub buyer_receive_account: Account<'info, TokenAccount>,
+    #[account(
+        mut,
+        constraint = seller_receiving_account.owner == listing.seller,
+        constraint = seller_receiving_account.mint == listing.mint
+    )]
+    pub seller_receiving_account: Account<'info, TokenAccount>,
+    #[account(
+        mut,
+        associated_token::mint = listing.mint,
+        associated_token::authority = listing,
+    )]
+    pub escrow_token_account: Account<'info, TokenAccount>,
+    #[account(
+        mut,
+        seeds = [b"fee_vault"],
+        bump,
+    )]
+    pub fee_vault: Account<'info, TokenAccount>,
+    /// CHECK: PDA authority for fee vault
+    #[account(seeds = [b"fee_vault"], bump)]
+    pub fee_vault_authority: UncheckedAccount<'info>,
+    pub token_program: Program<'info, Token>,
+}
+
+impl<'info> Buy<'info> {
+    fn pay_seller_context(&self) -> CpiContext<'_, '_, '_, 'info, Transfer<'info>> {
+        let cpi_accounts = Transfer {
+            from: self.buyer_payment_account.to_account_info(),
+            to: self.seller_receiving_account.to_account_info(),
+            authority: self.buyer.to_account_info(),
+        };
+        CpiContext::new(self.token_program.to_account_info(), cpi_accounts)
+    }
+    fn pay_fee_context(&self) -> CpiContext<'_, '_, '_, 'info, Transfer<'info>> {
+        let cpi_accounts = Transfer {
+            from: self.buyer_payment_account.to_account_info(),
+            to: self.fee_vault.to_account_info(),
+            authority: self.buyer.to_account_info(),
+        };
+        CpiContext::new(self.token_program.to_account_info(), cpi_accounts)
+    }
+    fn escrow_to_buyer_context(&self) -> CpiContext<'_, '_, '_, 'info, Transfer<'info>> {
+        let cpi_accounts = Transfer {
+            from: self.escrow_token_account.to_account_info(),
+            to: self.buyer_receive_account.to_account_info(),
+            authority: self.listing.to_account_info(),
+        };
+        CpiContext::new(self.token_program.to_account_info(), cpi_accounts)
+    }
+    fn close_escrow_context(&self) -> CpiContext<'_, '_, '_, 'info, CloseAccount<'info>> {
+        let cpi_accounts = CloseAccount {
+            account: self.escrow_token_account.to_account_info(),
+            destination: self.seller_receiving_account.to_account_info(),
+            authority: self.listing.to_account_info(),
+        };
+        CpiContext::new(self.token_program.to_account_info(), cpi_accounts)
+    }
+    fn listing_seeds(&self) -> [&[u8]; 5] {
+        [
+            b"listing",
+            self.listing.seller.as_ref(),
+            self.listing.mint.as_ref(),
+            &self.listing.nonce.to_le_bytes(),
+            &[self.listing.bump],
+        ]
+    }
+}
+
+#[derive(Accounts)]
+pub struct Cancel<'info> {
+    pub authority: Signer<'info>,
+    #[account(mut)]
+    pub listing: Account<'info, Listing>,
+    /// CHECK: seller of the listing
+    #[account(address = listing.seller)]
+    pub seller: AccountInfo<'info>,
+    #[account(
+        mut,
+        constraint = seller_token_account.owner == seller.key(),
+        constraint = seller_token_account.mint == listing.mint
+    )]
+    pub seller_token_account: Account<'info, TokenAccount>,
+    #[account(
+        mut,
+        associated_token::mint = listing.mint,
+        associated_token::authority = listing
+    )]
+    pub escrow_token_account: Account<'info, TokenAccount>,
+    pub token_program: Program<'info, Token>,
+}
+
+impl<'info> Cancel<'info> {
+    fn escrow_to_seller_context(&self) -> CpiContext<'_, '_, '_, 'info, Transfer<'info>> {
+        let cpi_accounts = Transfer {
+            from: self.escrow_token_account.to_account_info(),
+            to: self.seller_token_account.to_account_info(),
+            authority: self.listing.to_account_info(),
+        };
+        CpiContext::new(self.token_program.to_account_info(), cpi_accounts)
+    }
+    fn close_escrow_context(&self) -> CpiContext<'_, '_, '_, 'info, CloseAccount<'info>> {
+        let cpi_accounts = CloseAccount {
+            account: self.escrow_token_account.to_account_info(),
+            destination: self.seller.to_account_info(),
+            authority: self.listing.to_account_info(),
+        };
+        CpiContext::new(self.token_program.to_account_info(), cpi_accounts)
+    }
+    fn listing_seeds(&self) -> [&[u8]; 5] {
+        [
+            b"listing",
+            self.listing.seller.as_ref(),
+            self.listing.mint.as_ref(),
+            &self.listing.nonce.to_le_bytes(),
+            &[self.listing.bump],
+        ]
+    }
+}
+
+#[derive(Accounts)]
+pub struct WithdrawFee<'info> {
+    #[account(mut, address = ADMIN_PUBKEY)]
+    pub admin: Signer<'info>,
+    #[account(
+        mut,
+        constraint = admin_fee_account.owner == admin.key(),
+        constraint = admin_fee_account.mint == fee_vault.mint
+    )]
+    pub admin_fee_account: Account<'info, TokenAccount>,
+    #[account(mut, seeds=[b"fee_vault"], bump)]
+    pub fee_vault: Account<'info, TokenAccount>,
+    /// CHECK: PDA authority for fee vault
+    #[account(seeds=[b"fee_vault"], bump)]
+    pub fee_vault_authority: UncheckedAccount<'info>,
+    pub token_program: Program<'info, Token>,
+}
+
+impl<'info> WithdrawFee<'info> {
+    fn vault_to_admin_context(&self) -> CpiContext<'_, '_, '_, 'info, Transfer<'info>> {
+        let cpi_accounts = Transfer {
+            from: self.fee_vault.to_account_info(),
+            to: self.admin_fee_account.to_account_info(),
+            authority: self.fee_vault_authority.to_account_info(),
+        };
+        CpiContext::new(self.token_program.to_account_info(), cpi_accounts)
+    }
+}
+
+#[account]
+pub struct Listing {
+    pub seller: Pubkey,
+    pub mint: Pubkey,
+    pub price: u64,
+    pub quantity: u64,
+    pub expiry: i64,
+    pub status: u8,
+    pub bump: u8,
+    pub nonce: u64,
+}
+
+impl Listing {
+    pub const LEN: usize = 8 + 32 + 32 + 8 + 8 + 8 + 1 + 1 + 8;
+}
+
+#[repr(u8)]
+pub enum ListingStatus {
+    Open = 0,
+    Settled = 1,
+    Canceled = 2,
+}
+
+#[event]
+pub struct ListingCreated {
+    pub seller: Pubkey,
+    pub listing: Pubkey,
+    pub mint: Pubkey,
+    pub price: u64,
+    pub quantity: u64,
+}
+
+#[event]
+pub struct Purchased {
+    pub listing: Pubkey,
+    pub buyer: Pubkey,
+    pub price: u64,
+}
+
+#[event]
+pub struct Canceled {
+    pub listing: Pubkey,
+    pub seller: Pubkey,
+}
+
+#[event]
+pub struct FeeWithdrawn {
+    pub admin: Pubkey,
+    pub amount: u64,
+}
+
+#[error_code]
+pub enum EscrowError {
+    #[msg("Listing is not in correct state")]
+    InvalidState,
+    #[msg("Unauthorized")]
+    Unauthorized,
+    #[msg("Overflow")]
+    Overflow,
+    #[msg("Invalid quantity")]
+    InvalidQuantity,
+    #[msg("Invalid price")]
+    InvalidPrice,
+}

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "escrow-market-ts",
+  "version": "0.1.0",
+  "scripts": {
+    "test": "mocha -t 1000000 -r ts-node/register tests/**/*.ts"
+  },
+  "dependencies": {
+    "@coral-xyz/anchor": "^0.29.0",
+    "@solana/spl-token": "^0.4.0",
+    "@solana/web3.js": "^1.80.0"
+  },
+  "devDependencies": {
+    "@types/mocha": "^10.0.1",
+    "@types/node": "^18.15.11",
+    "mocha": "^10.2.0",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.0.4"
+  }
+}

--- a/ts/sdk/index.ts
+++ b/ts/sdk/index.ts
@@ -1,0 +1,64 @@
+import { PublicKey, TransactionInstruction, SystemProgram } from '@solana/web3.js';
+import { BN, Program } from '@coral-xyz/anchor';
+import { TOKEN_PROGRAM_ID, ASSOCIATED_TOKEN_PROGRAM_ID } from '@solana/spl-token';
+import { EscrowMarket } from '../../target/types/escrow_market';
+
+export const PROGRAM_ID = new PublicKey(process.env.PROGRAM_ID ?? 'Escrow1111111111111111111111111111111111111');
+
+export const listingPda = (seller: PublicKey, mint: PublicKey, nonce: BN) =>
+  PublicKey.findProgramAddressSync(
+    [Buffer.from('listing'), seller.toBuffer(), mint.toBuffer(), nonce.toArrayLike(Buffer, 'le', 8)],
+    PROGRAM_ID
+  );
+
+export const feeVaultPda = () => PublicKey.findProgramAddressSync([Buffer.from('fee_vault')], PROGRAM_ID);
+
+export const escrowAta = (listing: PublicKey, mint: PublicKey) =>
+  PublicKey.findProgramAddressSync([listing.toBuffer(), TOKEN_PROGRAM_ID.toBuffer(), mint.toBuffer()], ASSOCIATED_TOKEN_PROGRAM_ID);
+
+export const createListingIx = async (
+  program: Program<EscrowMarket>,
+  seller: PublicKey,
+  mint: PublicKey,
+  sellerToken: PublicKey,
+  price: BN,
+  qty: BN,
+  expiry: BN,
+  nonce: BN
+): Promise<TransactionInstruction> => {
+  const [listing] = listingPda(seller, mint, nonce);
+  const [escrow] = escrowAta(listing, mint);
+  return program.methods.createListing(price, qty, expiry, nonce).accounts({
+    seller,
+    listing,
+    mint,
+    sellerTokenAccount: sellerToken,
+    escrowTokenAccount: escrow,
+    tokenProgram: TOKEN_PROGRAM_ID,
+    associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
+    systemProgram: SystemProgram.programId
+  }).instruction();
+};
+
+export const buyIx = async (
+  program: Program<EscrowMarket>,
+  buyer: PublicKey,
+  listing: PublicKey,
+  buyerPay: PublicKey,
+  buyerReceive: PublicKey,
+  sellerReceive: PublicKey
+): Promise<TransactionInstruction> => {
+  const [feeVault] = feeVaultPda();
+  const [feeVaultAuthority] = feeVaultPda();
+  return program.methods.buy().accounts({
+    buyer,
+    listing,
+    buyerPaymentAccount: buyerPay,
+    buyerReceiveAccount: buyerReceive,
+    sellerReceivingAccount: sellerReceive,
+    escrowTokenAccount: (await escrowAta(listing, buyerReceive))[0],
+    feeVault,
+    feeVaultAuthority,
+    tokenProgram: TOKEN_PROGRAM_ID
+  }).instruction();
+};

--- a/ts/tests/escrow.spec.ts
+++ b/ts/tests/escrow.spec.ts
@@ -1,0 +1,117 @@
+import * as anchor from '@coral-xyz/anchor';
+import { Program, BN } from '@coral-xyz/anchor';
+import { EscrowMarket } from '../../target/types/escrow_market';
+import {
+  createMint,
+  getOrCreateAssociatedTokenAccount,
+  mintTo,
+  TOKEN_PROGRAM_ID
+} from '@solana/spl-token';
+import { listingPda, feeVaultPda } from '../sdk';
+
+describe('escrow_market', () => {
+  const provider = anchor.AnchorProvider.env();
+  anchor.setProvider(provider);
+  const program = anchor.workspace.EscrowMarket as Program<EscrowMarket>;
+
+  let mint: anchor.web3.PublicKey;
+  let sellerToken: anchor.web3.PublicKey;
+  let buyerToken: anchor.web3.PublicKey;
+  let seller = anchor.web3.Keypair.generate();
+  let buyer = anchor.web3.Keypair.generate();
+  const price = new BN(100);
+  const qty = new BN(50);
+  const nonce = new BN(1);
+  const expiry = new BN(Math.floor(Date.now() / 1000) + 3600);
+
+  it('setup accounts', async () => {
+    await provider.connection.confirmTransaction(
+      await provider.connection.requestAirdrop(seller.publicKey, 1e9)
+    );
+    await provider.connection.confirmTransaction(
+      await provider.connection.requestAirdrop(buyer.publicKey, 1e9)
+    );
+    mint = await createMint(provider.connection, seller, seller.publicKey, null, 0);
+    sellerToken = (await getOrCreateAssociatedTokenAccount(provider.connection, seller, mint, seller.publicKey)).address;
+    buyerToken = (await getOrCreateAssociatedTokenAccount(provider.connection, buyer, mint, buyer.publicKey)).address;
+    await mintTo(provider.connection, seller, mint, sellerToken, seller, 200);
+    await mintTo(provider.connection, seller, mint, buyerToken, seller, 200);
+  });
+
+  it('create listing', async () => {
+    await program.methods
+      .createListing(price, qty, expiry, nonce)
+      .accounts({
+        seller: seller.publicKey,
+        mint,
+        sellerTokenAccount: sellerToken
+      })
+      .signers([seller])
+      .rpc();
+
+    const [listing] = listingPda(seller.publicKey, mint, nonce);
+    const l = await program.account.listing.fetch(listing);
+    anchor.assert(l.price.eq(price));
+  });
+
+  it('buy listing', async () => {
+    const [listing] = listingPda(seller.publicKey, mint, nonce);
+    const feeVault = (await feeVaultPda())[0];
+    await program.methods
+      .buy()
+      .accounts({
+        buyer: buyer.publicKey,
+        listing,
+        buyerPaymentAccount: buyerToken,
+        buyerReceiveAccount: buyerToken,
+        sellerReceivingAccount: sellerToken,
+        escrowTokenAccount: (await anchor.utils.token.associatedAddress({ mint, owner: listing })),
+        feeVault,
+        feeVaultAuthority: feeVault,
+        tokenProgram: TOKEN_PROGRAM_ID
+      })
+      .signers([buyer])
+      .rpc();
+    const l = await program.account.listing.fetch(listing);
+    anchor.assert.equal(l.status, 1);
+  });
+
+  it('double buy fails', async () => {
+    const [listing] = listingPda(seller.publicKey, mint, nonce);
+    try {
+      await program.methods
+        .buy()
+        .accounts({
+          buyer: buyer.publicKey,
+          listing,
+          buyerPaymentAccount: buyerToken,
+          buyerReceiveAccount: buyerToken,
+          sellerReceivingAccount: sellerToken,
+          escrowTokenAccount: (await anchor.utils.token.associatedAddress({ mint, owner: listing })),
+          feeVault: (await feeVaultPda())[0],
+          feeVaultAuthority: (await feeVaultPda())[0],
+          tokenProgram: TOKEN_PROGRAM_ID
+        })
+        .signers([buyer])
+        .rpc();
+      throw new Error('should fail');
+    } catch (err) {
+      // expected
+    }
+  });
+
+  it('withdraw fee', async () => {
+    const feeVault = (await feeVaultPda())[0];
+    const adminToken = buyerToken; // demo
+    await program.methods
+      .withdrawFee(new BN(1))
+      .accounts({
+        admin: provider.wallet.publicKey,
+        adminFeeAccount: adminToken,
+        feeVault,
+        feeVaultAuthority: feeVault,
+        tokenProgram: TOKEN_PROGRAM_ID
+      })
+      .rpc();
+  });
+});

--- a/ts/tsconfig.json
+++ b/ts/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2019",
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "types": ["mocha", "node"],
+    "strict": true,
+    "skipLibCheck": true,
+    "sourceMap": true
+  },
+  "include": ["sdk", "tests"]
+}


### PR DESCRIPTION
## Summary
- add Anchor escrow program with fee vault and events
- scaffold React frontend and TypeScript SDK/tests
- document usage and security considerations

## Testing
- `cargo clippy --manifest-path programs/escrow_market/Cargo.toml -- -D warnings` *(failed: failed to get `anchor-lang` from crates.io, response 403)*
- `anchor build` *(command not found, anchor installation failed due to network 403)*
- `cd app && npm install` *(failed: 403 Forbidden from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_689eec93d5ac83209d089eca6b56297e